### PR TITLE
fix: keyboard buttons trigger form submission when parent is form

### DIFF
--- a/src/lib/Keyboard.svelte
+++ b/src/lib/Keyboard.svelte
@@ -108,6 +108,7 @@
         <div class="row row--{i}">
           {#each keys as { value, display }}
             <button
+              type="button"
               class="key key--{value} {keyClass[value] || ''}"
               class:single="{value.length === 1}"
               class:active="{value === active}"
@@ -196,6 +197,6 @@
 
   :global(.svelte-keyboard svg) {
     stroke-width: var(--stroke-width, 2px);
-		vertical-align: middle;
+    vertical-align: middle;
   }
 </style>


### PR DESCRIPTION
By default, buttons without a `type="button"` attribute submit the form they are nested within. This PR adds `type="button"` so forms are not submitted from keyboard button presses.