### PR TITLE
Add missing export condition

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -37,7 +37,9 @@
 		"./layouts/qwerty/wordle": "./layouts/qwerty/wordle.js",
 		"./svg/backspace": "./svg/backspace.js",
 		"./svg/enter": "./svg/enter.js",
-		".": "./Keyboard.svelte"
+		".": {
+			"svelte": "./Keyboard.svelte"
+		}
 	},
 	"type": "module",
 	"typings": "./Keyboard.svelte.d.ts",


### PR DESCRIPTION
Whenever the `svelte` field is used in `package.json`, there needs to be an export condition in there as well. More info here: https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition.

I'm sorry if this a mess. I'm open for edits. This is my first time doing a PR but not my first time publishing to NPM so I only edited the `package.json` file in `package` directory, which also exactly contains the `svelte` field. The top-level `package.json` doesn't have the `svelte` field but it does have the `exports` field, but I'm not sure if I should touch it.